### PR TITLE
Remove Community section and its Swiper init

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,70 +323,7 @@
             </div>
         </section>
 
-        <!-- ===== Community Section ===== -->
-        <section id="community" class="py-20 md:py-28 bg-gray-100">
-            <div class="container mx-auto px-6">
-                <div class="text-center">
-                    <h2 class="text-3xl md:text-4xl font-bold text-navy section-title reveal">Community</h2>
-                </div>
-                <div class="mt-16 reveal">
-                    <div class="swiper community-swiper">
-                        <div class="swiper-wrapper">
-                            <div class="swiper-slide p-2">
-                                <div class="case-card h-tech-card rounded-xl reveal">
-                                    <div class="p-8 text-left flex-grow flex flex-col">
-                                        <span class="text-sky-500 font-bold text-sm">学生向け</span>
-                                        <h3 class="text-xl font-bold my-2 text-navy">ShibuyaStarterBase</h3>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="swiper-slide p-2">
-                                <div class="case-card h-tech-card rounded-xl reveal reveal-medium">
-                                    <div class="p-8 text-left flex-grow flex flex-col">
-                                        <span class="text-sky-500 font-bold text-sm">フリーランス向け</span>
-                                        <h3 class="text-xl font-bold my-2 text-navy">ShibuyaProfessionalBase</h3>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="swiper-slide p-2">
-                                <div class="case-card h-tech-card rounded-xl reveal reveal-slow">
-                                    <div class="p-8 text-left flex-grow flex flex-col">
-                                        <span class="text-sky-500 font-bold text-sm">早稲田総合研究会</span>
-                                        <h3 class="text-xl font-bold my-2 text-navy">キャリア研究部</h3>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="swiper-slide p-2">
-                                <div class="case-card h-tech-card rounded-xl reveal">
-                                    <div class="p-8 text-left flex-grow flex flex-col">
-                                        <span class="text-sky-500 font-bold text-sm">早稲田総合研究会</span>
-                                        <h3 class="text-xl font-bold my-2 text-navy">AI研究部</h3>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="swiper-slide p-2">
-                                <div class="case-card h-tech-card rounded-xl reveal">
-                                    <div class="p-8 text-left flex-grow flex flex-col">
-                                        <span class="text-sky-500 font-bold text-sm">早稲田総合研究会</span>
-                                        <h3 class="text-xl font-bold my-2 text-navy">メディア研究部</h3>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="swiper-slide p-2">
-                                <div class="case-card h-tech-card rounded-xl reveal">
-                                    <div class="p-8 text-left flex-grow flex flex-col">
-                                        <span class="text-sky-500 font-bold text-sm">早稲田総合研究会</span>
-                                        <h3 class="text-xl font-bold my-2 text-navy">起業部</h3>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="swiper-pagination"></div>
-                        <div class="swiper-button-next"></div><div class="swiper-button-prev"></div>
-                    </div>
-                </div>
-            </div>
-        </section>
+        
 
         <!-- ===== Projects Section ===== -->
         <section id="cases" class="py-20 md:py-28 bg-gray-100">
@@ -769,21 +706,7 @@
                 },
             });
 
-            const communitySwiper = new Swiper('.community-swiper', {
-                loop: true,
-                slidesPerView: 1,
-                spaceBetween: 20,
-                pagination: { el: '.swiper-pagination', clickable: true },
-                navigation: { nextEl: '.swiper-button-next', prevEl: '.swiper-button-prev' },
-                breakpoints: {
-                    768: { slidesPerView: 2, spaceBetween: 25 },
-                    1024: { slidesPerView: 3, spaceBetween: 30 },
-                },
-                autoplay: {
-                    delay: 5000,
-                    disableOnInteraction: false,
-                },
-            });
+            
         });
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -328,68 +328,55 @@
             <div class="container mx-auto px-6">
                 <div class="text-center">
                     <h2 class="text-3xl md:text-4xl font-bold text-navy section-title reveal">Community</h2>
-                    <p class="mt-4 text-gray-600 reveal reveal-fast">多様なバックグラウンドを持つメンバーが集い、成長と挑戦の場を提供しています。</p>
                 </div>
                 <div class="mt-16 reveal">
                     <div class="swiper community-swiper">
                         <div class="swiper-wrapper">
                             <div class="swiper-slide p-2">
                                 <div class="case-card h-tech-card rounded-xl reveal">
-                                    <div class="img-container rounded-t-xl"><img src="https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?q=80&w=800&auto=format&fit=crop" alt="ShibuyaStarterBase" class="w-full rounded-t-xl"></div>
                                     <div class="p-8 text-left flex-grow flex flex-col">
                                         <span class="text-sky-500 font-bold text-sm">学生向け</span>
                                         <h3 class="text-xl font-bold my-2 text-navy">ShibuyaStarterBase</h3>
-                                        <p class="text-sm text-gray-700 flex-grow">フリーランスや起業を目指すメンバーが集う成長志向のコミュニティ。AIコンサル部、エンジニア部、営業部などの部署で実践的なスキルを磨き、仲間と協働しながらプロジェクトに挑戦できます。キャリア支援や情報交換も活発で、挑戦したい人のための最適な環境です。</p>
                                     </div>
                                 </div>
                             </div>
                             <div class="swiper-slide p-2">
                                 <div class="case-card h-tech-card rounded-xl reveal reveal-medium">
-                                    <div class="img-container rounded-t-xl"><img src="https://images.unsplash.com/photo-1465101046530-73398c7f28ca?q=80&w=800&auto=format&fit=crop" alt="ShibuyaProfessionalBase" class="w-full rounded-t-xl"></div>
                                     <div class="p-8 text-left flex-grow flex flex-col">
                                         <span class="text-sky-500 font-bold text-sm">フリーランス向け</span>
                                         <h3 class="text-xl font-bold my-2 text-navy">ShibuyaProfessionalBase</h3>
-                                        <p class="text-sm text-gray-700 flex-grow">フリーランスや起業家のための実践的なビジネスコミュニティ。案件獲得や協業の機会を提供し、メンバー同士で切磋琢磨しながらスキルアップやネットワーキング、最新情報の交換ができる場です。多様な分野のプロフェッショナルが集い、成長と挑戦を支援します。</p>
                                     </div>
                                 </div>
                             </div>
                             <div class="swiper-slide p-2">
                                 <div class="case-card h-tech-card rounded-xl reveal reveal-slow">
-                                    <div class="img-container rounded-t-xl"><img src="https://images.unsplash.com/photo-1503676382389-4809596d5290?q=80&w=800&auto=format&fit=crop" alt="キャリア研究部~早稲田総合研究会~" class="w-full rounded-t-xl"></div>
                                     <div class="p-8 text-left flex-grow flex flex-col">
                                         <span class="text-sky-500 font-bold text-sm">早稲田総合研究会</span>
                                         <h3 class="text-xl font-bold my-2 text-navy">キャリア研究部</h3>
-                                        <p class="text-sm text-gray-700 flex-grow">学生のキャリア形成を支援するための部門。業界研究やOB・OG交流、インターンシップ情報の共有などを通じて、将来の進路選択や就職活動に役立つ知識と経験を提供します。</p>
                                     </div>
                                 </div>
                             </div>
                             <div class="swiper-slide p-2">
                                 <div class="case-card h-tech-card rounded-xl reveal">
-                                    <div class="img-container rounded-t-xl"><img src="https://images.unsplash.com/photo-1519389950473-47ba0277781c?q=80&w=800&auto=format&fit=crop" alt="AI研究部~早稲田総合研究会~" class="w-full rounded-t-xl"></div>
                                     <div class="p-8 text-left flex-grow flex flex-col">
                                         <span class="text-sky-500 font-bold text-sm">早稲田総合研究会</span>
                                         <h3 class="text-xl font-bold my-2 text-navy">AI研究部</h3>
-                                        <p class="text-sm text-gray-700 flex-grow">AI技術やデータサイエンスに興味のある学生が集まり、勉強会やプロジェクトを通じて最先端の知識を学び、実践的なスキルを身につけることができます。</p>
                                     </div>
                                 </div>
                             </div>
                             <div class="swiper-slide p-2">
                                 <div class="case-card h-tech-card rounded-xl reveal">
-                                    <div class="img-container rounded-t-xl"><img src="https://images.unsplash.com/photo-1464983953574-0892a716854b?q=80&w=800&auto=format&fit=crop" alt="メディア研究部~早稲田総合研究会~" class="w-full rounded-t-xl"></div>
                                     <div class="p-8 text-left flex-grow flex flex-col">
                                         <span class="text-sky-500 font-bold text-sm">早稲田総合研究会</span>
                                         <h3 class="text-xl font-bold my-2 text-navy">メディア研究部</h3>
-                                        <p class="text-sm text-gray-700 flex-grow">メディアや広報、情報発信に関心のある学生が、記事執筆やSNS運用、イベント企画などを通じて、実践的なメディア運営スキルを身につけます。</p>
                                     </div>
                                 </div>
                             </div>
                             <div class="swiper-slide p-2">
                                 <div class="case-card h-tech-card rounded-xl reveal">
-                                    <div class="img-container rounded-t-xl"><img src="https://images.unsplash.com/photo-1461749280684-dccba630e2f6?q=80&w=800&auto=format&fit=crop" alt="起業部~早稲田総合研究会~" class="w-full rounded-t-xl"></div>
                                     <div class="p-8 text-left flex-grow flex flex-col">
                                         <span class="text-sky-500 font-bold text-sm">早稲田総合研究会</span>
                                         <h3 class="text-xl font-bold my-2 text-navy">起業部</h3>
-                                        <p class="text-sm text-gray-700 flex-grow">起業に関心のある学生が集まり、ビジネスプランの作成やピッチイベント、起業家との交流を通じて、実践的な起業ノウハウやマインドを養います。</p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Summary: Community セクション（見出し・各スライドのラベル・タイトル含む）を全面削除し、関連する Swiper 初期化コードも削除しました。\n\nChanges:\n- Remove Community section markup from index.html\n- Remove community-swiper の初期化コード（communitySwiper）\n\nRationale:\n- 当該コンテンツの公開不要化のため\n\nImpact:\n- 他セクション（Services, Projects）のスライダーや UI への影響なし\n\nNote:\n- ナビゲーションからの #community 参照がないことを確認